### PR TITLE
Clarify that it only works with NSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ solid-file-python is a Python library for creating and managing files and folder
 
 Read and try it on [jupiter notebook](https://github.com/twonote/solid-file-python/blob/master/solid-file-python-getting-start.ipynb) now!
 
+# Limitations
+
+Currently the authentication process relies on endpoints and cookies by the node-solid-server. Therefore, at least for now, authentication with other pod providers won't work.
+
 # What is Solid?
 
 Solid is a specification that lets people store their data securely in decentralized data stores called Pods. Learn more about Solid on [solidproject.org](https://solidproject.org/).


### PR DESCRIPTION
Looking at auth.py this project relies on a `/login/password` endpoint and the `nssidp.sid` cookie. I think both of these are not standardized and only work with NSS (at least **nss**idp.sid suggests it is NSS specific).

It would make sense to clarify this in the README so users don't get wrong expectations (as in #30).